### PR TITLE
fix: prevent nav button layout shift on click

### DIFF
--- a/src/shared/custom-navbar/custom-navbar.component.html
+++ b/src/shared/custom-navbar/custom-navbar.component.html
@@ -1,10 +1,10 @@
 <nav>
   <ul>
     <li><a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}" aria-label="Greeting"><mat-icon aria-hidden="true">exit_to_app</mat-icon></a></li>
-    <li><a routerLink="/home" routerLinkActive="active-link">Home</a></li>
-    <li><a routerLink="/background" routerLinkActive="active-link">Background</a></li>
-    <li><a routerLink="/interests" routerLinkActive="active-link">Interests</a></li>
-    <li><a routerLink="/projects" routerLinkActive="active-link">Projects</a></li>
-    <li><a routerLink="/blog" routerLinkActive="active-link">Blog</a></li>
+    <li><a routerLink="/home" routerLinkActive="active-link"><span>Home</span></a></li>
+    <li><a routerLink="/background" routerLinkActive="active-link"><span>Background</span></a></li>
+    <li><a routerLink="/interests" routerLinkActive="active-link"><span>Interests</span></a></li>
+    <li><a routerLink="/projects" routerLinkActive="active-link"><span>Projects</span></a></li>
+    <li><a routerLink="/blog" routerLinkActive="active-link"><span>Blog</span></a></li>
   </ul>
 </nav>

--- a/src/shared/custom-navbar/custom-navbar.component.scss
+++ b/src/shared/custom-navbar/custom-navbar.component.scss
@@ -30,7 +30,6 @@ nav ul {
   }
 
   a {
-    position: relative;
     border-radius: 1rem;
     padding: 0.5rem 1rem;
     display: flex;
@@ -48,31 +47,43 @@ nav ul {
     transition: background-color 0.3s ease;
   }
 
+  // Pre-reserve bracket space via color: transparent so brackets never
+  // cause layout shift when they become visible
+  a span {
+    display: inline-block;
+  }
+  a span::before {
+    content: "[ ";
+    color: transparent;
+  }
+  a span::after {
+    content: " ]";
+    color: transparent;
+  }
+
   // a:active = clicking navigation link behavior
   a:active {
     color: $accent-color;
   }
-  a:active::before {
-    content: "{ ";
-    position: absolute;
-    left: 0.4rem;
+  // !important needed: a:active and a.active-link have equal specificity,
+  // so !important ensures :active wins when both apply simultaneously
+  a:active span::before {
+    content: "{ " !important;
+    color: $accent-color !important;
   }
-  a:active::after {
-    content: " }";
-    position: absolute;
-    right: 0.4rem;
+  a:active span::after {
+    content: " }" !important;
+    color: $accent-color !important;
   }
 
   // a.active-link = on current navigation link behavior
-  a.active-link::before {
+  a.active-link span::before {
     content: "[ ";
-    position: absolute;
-    left: 0.4rem;
+    color: $accent-color;
   }
-  a.active-link::after {
+  a.active-link span::after {
     content: " ]";
-    position: absolute;
-    right: 0.4rem;
+    color: $accent-color;
   }
   a.active-link {
     font-weight: bold;

--- a/src/shared/custom-navbar/custom-navbar.component.scss
+++ b/src/shared/custom-navbar/custom-navbar.component.scss
@@ -30,6 +30,7 @@ nav ul {
   }
 
   a {
+    position: relative;
     border-radius: 1rem;
     padding: 0.5rem 1rem;
     display: flex;
@@ -52,18 +53,26 @@ nav ul {
     color: $accent-color;
   }
   a:active::before {
-    content: "{ " !important;
+    content: "{ ";
+    position: absolute;
+    left: 0.4rem;
   }
   a:active::after {
-    content: " }" !important;
+    content: " }";
+    position: absolute;
+    right: 0.4rem;
   }
 
   // a.active-link = on current navigation link behavior
   a.active-link::before {
     content: "[ ";
+    position: absolute;
+    left: 0.4rem;
   }
   a.active-link::after {
     content: " ]";
+    position: absolute;
+    right: 0.4rem;
   }
   a.active-link {
     font-weight: bold;


### PR DESCRIPTION
Use position: absolute on bracket pseudo-elements so they are placed within the button's existing padding area rather than adding to its layout width. Buttons remain static size while brackets appear on :active and .active-link states without causing wrapping.