### PR TITLE
Changing "Recent Achievements" to Utilize the RuneProfile API

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,15 +26,16 @@ npm test -- --watch=false --browsers=ChromeHeadless --no-progress
 ```
 src/
   app/               # Page components (one folder per route)
-  shared/            # Reusable components and styles
+  shared/            # Reusable components, services, and styles
     base-page/       # Shell component wrapping CustomNavbarComponent
     custom-navbar/   # Navigation bar
+    services/        # Angular services (e.g. WiseOldManService, RuneProfileService)
     route-transition.ts  # Shared animation trigger
     shared-styles.scss   # Shared utility mixins (e.g. scrollbar-styled)
   styles.scss        # Global styles and color variables
 ```
 
-**Page structure:** Each route has its own folder under `src/app/<name>-page/`. Pages import `BasePageComponent` to get the navbar. The `App` component (`src/app/app.ts`) applies route animations via `@routeAnimations`.
+**Page structure:** Each route has its own folder under `src/app/<name>-page/`. Pages import `BasePageComponent` to get the navbar. The `App` component (`src/app/app.ts`) applies route animations via `@routeAnimations`. Complex pages may contain nested sub-components in subfolders (e.g. `interests-page/osrs-stats/`).
 
 **Routing:** Defined in `src/app/app.routes.ts`. Every route requires a `data: { animation: 'UniqueName' }` property for the slide transition to work.
 
@@ -50,7 +51,7 @@ For navigation, prefer `routerLink` directive over imperative `Router.navigate()
 
 **New pages:** Import `BasePageComponent` (not `CustomNavbarComponent` directly) to get the shared navbar. Register the route in `app.routes.ts` with an `animation` data key.
 
-**Component metadata style:** Use `styleUrl` (singular) and `templateUrl`. Imports should have spaces after `{`.
+**Component metadata style:** Use `styleUrl` (singular) and `templateUrl`. Imports should have spaces after `{`. Top-level page components follow the `*.component.ts/html/scss` naming convention. Sub-components generated via Angular CLI (e.g. `ng generate component`) may omit the `.component.` infix — both patterns exist in the codebase.
 ```ts
 @Component({
   selector: 'app-my-page',

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ My personal website built with Angular, TypeScript, and SCSS — live at [morgan
 | `/` | Greeting / landing |
 | `/home` | About me, social links |
 | `/background` | 🚧 Coming soon |
-| `/interests` | Music (stats.fm) + OSRS stats (Wise Old Man) |
+| `/interests` | Music (stats.fm) + OSRS stats (Wise Old Man, RuneProfile) |
 | `/projects` | 🚧 Coming soon |
 | `/blog` | 🚧 Coming soon |
 

--- a/src/app/interests-page/osrs-stats/osrs-stats.html
+++ b/src/app/interests-page/osrs-stats/osrs-stats.html
@@ -157,14 +157,9 @@
             <ul class="activities-list">
               @for (achievement of achievements; track $index) {
                 <li class="activity-item">
-                  @let icon = achievementIcon(achievement);
-                  @if (icon.type === 'skill') {
-                    <img [src]="icon.src" class="activity-icon" [alt]="achievement.metric" loading="lazy" />
-                  } @else {
-                    <span class="activity-icon-emoji">{{ icon.value }}</span>
-                  }
+                  <img [src]="achievementActivityIcon(achievement)" class="activity-icon" [alt]="achievement.type" loading="lazy" />
                   <div class="activity-info">
-                    <span class="activity-label">{{ achievement.name }}</span>
+                    <span class="activity-label">{{ formatAchievementLabel(achievement) }}</span>
                     <span class="activity-meta">{{ formatDate(achievement.createdAt) }}</span>
                   </div>
                 </li>

--- a/src/app/interests-page/osrs-stats/osrs-stats.html
+++ b/src/app/interests-page/osrs-stats/osrs-stats.html
@@ -157,7 +157,7 @@
             <ul class="activities-list">
               @for (achievement of achievements; track $index) {
                 <li class="activity-item">
-                  <img [src]="achievementActivityIcon(achievement)" class="activity-icon" [alt]="achievement.type" loading="lazy" />
+                  <img [src]="achievementActivityIcon(achievement)" class="activity-icon" [alt]="formatAchievementLabel(achievement)" loading="lazy" />
                   <div class="activity-info">
                     <span class="activity-label">{{ formatAchievementLabel(achievement) }}</span>
                     <span class="activity-meta">{{ formatDate(achievement.createdAt) }}</span>

--- a/src/app/interests-page/osrs-stats/osrs-stats.ts
+++ b/src/app/interests-page/osrs-stats/osrs-stats.ts
@@ -252,7 +252,7 @@ export class OsrsStatsComponent implements OnInit {
   private formatXp(xp: number): string {
     if (xp >= 1_000_000_000) return `${(xp / 1_000_000_000).toFixed(1)}B`;
     if (xp >= 1_000_000) return `${Math.floor(xp / 1_000_000)}M`;
-    if (xp >= 1_000) return `${Math.round(xp / 1_000)}K`;
+    if (xp >= 1_000) return `${Math.floor(xp / 1_000)}K`;
     return `${xp}`;
   }
 

--- a/src/app/interests-page/osrs-stats/osrs-stats.ts
+++ b/src/app/interests-page/osrs-stats/osrs-stats.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
-import { WiseOldManService, WomPlayer, WomBoss, WomAchievement } from '../../../shared/services/wise-old-man.service';
+import { WiseOldManService, WomPlayer, WomBoss } from '../../../shared/services/wise-old-man.service';
 import { RuneProfileService, RpCollectionLogItem, RpActivity, RpActivityType, RpCombatTier } from '../../../shared/services/rune-profile.service';
 import { Observable, tap, map, catchError, of } from 'rxjs';
 
@@ -8,6 +8,15 @@ const WOM_USERNAME = 'TipodissDong';
 const DISPLAY_LIMIT = 20;
 
 const DROP_ACTIVITY_TYPES: RpActivityType[] = ['valuable_drop', 'new_item_obtained'];
+
+const ACHIEVEMENT_ACTIVITY_TYPES: RpActivityType[] = [
+  'level_up',
+  'quest_completed',
+  'achievement_diary_tier_completed',
+  'combat_achievement_tier_completed',
+  'combat_achievement_tier_reached',
+  'xp_milestone',
+];
 
 // Ordered to match the in-game Skills tab layout (3 columns, top to bottom)
 const SKILL_ORDER = [
@@ -83,7 +92,7 @@ export class OsrsStatsComponent implements OnInit {
   player$!: Observable<WomPlayer | null>;
   pets$!: Observable<RpCollectionLogItem[]>;
   drops$!: Observable<RpActivity[]>;
-  achievements$!: Observable<WomAchievement[]>;
+  achievements$!: Observable<RpActivity[]>;
   questSummary$!: Observable<QuestSummary | null>;
   diaryTierTotals$!: Observable<DiaryTierTotal[] | null>;
   combatSummary$!: Observable<CombatSummary | null>;
@@ -125,18 +134,15 @@ export class OsrsStatsComponent implements OnInit {
         return of([]);
       })
     );
-    this.drops$ = this.runeProfile.getActivities(WOM_USERNAME).pipe(
-      map(response => response.activities
-        .filter(a => DROP_ACTIVITY_TYPES.includes(a.type))
-        .slice(0, DISPLAY_LIMIT)
-      ),
+    this.drops$ = this.runeProfile.getActivities(WOM_USERNAME, DROP_ACTIVITY_TYPES).pipe(
+      map(response => response.activities.slice(0, DISPLAY_LIMIT)),
       catchError(() => {
         this.dropsLoadFailed = true;
         return of([]);
       })
     );
-    this.achievements$ = this.wom.getAchievements(WOM_USERNAME).pipe(
-      map(items => items.slice(0, DISPLAY_LIMIT)),
+    this.achievements$ = this.runeProfile.getActivities(WOM_USERNAME, ACHIEVEMENT_ACTIVITY_TYPES).pipe(
+      map(response => response.activities.slice(0, DISPLAY_LIMIT)),
       catchError(() => {
         this.achievementsLoadFailed = true;
         return of([]);
@@ -210,14 +216,44 @@ export class OsrsStatsComponent implements OnInit {
     return new Date(dateStr).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
   }
 
-  achievementIcon(achievement: WomAchievement): { type: 'skill'; src: string } | { type: 'emoji'; value: string } {
-    if (achievement.metric === 'overall') {
-      return { type: 'skill', src: 'osrs/icons/skills-icon.png' };
+  achievementActivityIcon(activity: RpActivity): string {
+    if (activity.type === 'level_up') {
+      return `osrs/skills/${this.normalizeSkillName(activity.data.name)}_icon.png`;
     }
-    if ((SKILL_ORDER as readonly string[]).includes(achievement.metric)) {
-      return { type: 'skill', src: `osrs/skills/${achievement.metric}_icon.png` };
+    if (activity.type === 'quest_completed') return 'osrs/icons/quests-icon.png';
+    if (activity.type === 'achievement_diary_tier_completed') return 'osrs/icons/diary-icon.png';
+    if (activity.type === 'combat_achievement_tier_completed' ||
+        activity.type === 'combat_achievement_tier_reached') return 'osrs/icons/combat-achievements-icon.png';
+    if (activity.type === 'xp_milestone') return 'osrs/icons/skills-icon.png';
+    return 'osrs/icons/skills-icon.png';
+  }
+
+  formatAchievementLabel(activity: RpActivity): string {
+    if (activity.type === 'level_up') return `${activity.data.name} ${activity.data.level}`;
+    if (activity.type === 'quest_completed') return activity.enriched.questName;
+    if (activity.type === 'achievement_diary_tier_completed') {
+      return `${activity.enriched.areaName} ${activity.enriched.tierName ?? ''} Diary`.trim();
     }
-    return { type: 'emoji', value: '⚔️' };
+    if (activity.type === 'combat_achievement_tier_completed' ||
+        activity.type === 'combat_achievement_tier_reached') {
+      return `${activity.enriched.tierName} Combat Achievements`;
+    }
+    if (activity.type === 'xp_milestone') {
+      return `${activity.data.name} ${this.formatXp(activity.data.xp)} XP`;
+    }
+    return 'Achievement';
+  }
+
+  private normalizeSkillName(name: string): string {
+    const lower = name.toLowerCase();
+    return lower === 'runecraft' ? 'runecrafting' : lower;
+  }
+
+  private formatXp(xp: number): string {
+    if (xp >= 1_000_000_000) return `${(xp / 1_000_000_000).toFixed(1)}B`;
+    if (xp >= 1_000_000) return `${Math.floor(xp / 1_000_000)}M`;
+    if (xp >= 1_000) return `${Math.round(xp / 1_000)}K`;
+    return `${xp}`;
   }
 
   dropIcon(activity: RpActivity): number {

--- a/src/shared/services/rune-profile.service.ts
+++ b/src/shared/services/rune-profile.service.ts
@@ -82,6 +82,12 @@ export interface RpCombatAchievementTierActivity extends RpActivityBase {
   enriched: { tierName: string };
 }
 
+export interface RpCombatAchievementTierReachedActivity extends RpActivityBase {
+  type: 'combat_achievement_tier_reached';
+  data: Record<string, unknown>;
+  enriched: { tierName: string };
+}
+
 export interface RpDiaryTierActivity extends RpActivityBase {
   type: 'achievement_diary_tier_completed';
   data: { tier: number; areaId?: number };
@@ -111,6 +117,7 @@ export type RpActivity =
   | RpNewItemActivity
   | RpQuestActivity
   | RpCombatAchievementTierActivity
+  | RpCombatAchievementTierReachedActivity
   | RpDiaryTierActivity
   | RpMaxedActivity
   | RpXpMilestoneActivity
@@ -136,9 +143,10 @@ export class RuneProfileService {
     );
   }
 
-  getActivities(username: string, cursor?: string): Observable<RpActivitiesResponse> {
+  getActivities(username: string, activityTypes?: RpActivityType[], cursor?: string): Observable<RpActivitiesResponse> {
     const params: Record<string, string> = {};
     if (cursor) params['cursor'] = cursor;
+    if (activityTypes?.length) params['activityTypes'] = activityTypes.join(',');
     return this.http.get<RpActivitiesResponse>(
       `${BASE_URL}/accounts/${encodeURIComponent(username)}/activities`,
       { params }

--- a/src/shared/services/wise-old-man.service.ts
+++ b/src/shared/services/wise-old-man.service.ts
@@ -33,17 +33,6 @@ export interface WomPlayer {
   latestSnapshot: { data: WomSnapshot };
 }
 
-export interface WomAchievement {
-  playerId: number;
-  name: string;
-  metric: string;
-  threshold: number;
-  accuracy: number;
-  createdAt: string;
-  measure: 'experience' | 'kills' | 'score' | 'levels';
-  legacy: boolean;
-}
-
 const BASE_URL = 'https://api.wiseoldman.net/v2';
 
 @Injectable({ providedIn: 'root' })
@@ -52,9 +41,5 @@ export class WiseOldManService {
 
   getPlayer(username: string): Observable<WomPlayer> {
     return this.http.get<WomPlayer>(`${BASE_URL}/players/${encodeURIComponent(username)}`);
-  }
-
-  getAchievements(username: string): Observable<WomAchievement[]> {
-    return this.http.get<WomAchievement[]>(`${BASE_URL}/players/${encodeURIComponent(username)}/achievements`);
   }
 }


### PR DESCRIPTION
This pull request updates the OSRS stats "Recent Achievements" section to use the RuneProfile API for achievement activities instead of Wise Old Man, and improves the display and filtering of achievements and drops. It also introduces new activity types and enhances the codebase for better extensibility and clarity.

**OSRS Achievements and Activities Refactor:**

* The "Recent Achievements" list now pulls data from the `RuneProfileService` using a set of defined achievement activity types, instead of the `WiseOldManService`. This enables richer data and more consistent activity handling. [[1]](diffhunk://#diff-a0955483e90c221c647bb47997d308f70dfce5ab910c3bd5e64fb137d32da0c4R12-R20) [[2]](diffhunk://#diff-a0955483e90c221c647bb47997d308f70dfce5ab910c3bd5e64fb137d32da0c4L86-R95) [[3]](diffhunk://#diff-a0955483e90c221c647bb47997d308f70dfce5ab910c3bd5e64fb137d32da0c4L128-R145)
* The UI for achievements is simplified: icons and labels are now generated based on the new activity types, with helper methods for formatting labels and icons for different achievement kinds. [[1]](diffhunk://#diff-9c1a662ebbde08c2d0830dd566a2a43dc0391aa2504b21e4a944087bab01db85L160-R162) [[2]](diffhunk://#diff-a0955483e90c221c647bb47997d308f70dfce5ab910c3bd5e64fb137d32da0c4L213-R256)

**API and Type Enhancements:**

* Added new activity type `combat_achievement_tier_reached` and its interface, and included it in the `RpActivity` union type for comprehensive activity support. [[1]](diffhunk://#diff-c916348b99cb82c979e4e3d70e6c377cfd65a333ad45fe9dfa17d882219fb3b7R85-R90) [[2]](diffhunk://#diff-c916348b99cb82c979e4e3d70e6c377cfd65a333ad45fe9dfa17d882219fb3b7R120)
* The `RuneProfileService.getActivities` method now accepts an optional list of activity types for server-side filtering, improving efficiency and flexibility.

**Cleanup and Documentation:**

* Removed the unused `WomAchievement` interface and related achievement-fetching code from `WiseOldManService`, since achievements are now handled exclusively via `RuneProfileService`. [[1]](diffhunk://#diff-a0955483e90c221c647bb47997d308f70dfce5ab910c3bd5e64fb137d32da0c4R12-R20) [[2]](diffhunk://#diff-47bc67116f7fda182589622690c8d40cd64feb092b1316453a787e29724a3078L36-L46) [[3]](diffhunk://#diff-47bc67116f7fda182589622690c8d40cd64feb092b1316453a787e29724a3078L56-L59)
* Updated documentation and comments to reflect the new structure, including clarifying the role of the `shared/services/` folder and updating the list of data sources in the README. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L29-R38) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L53-R54) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19)

These changes modernize the achievements pipeline, make the codebase easier to extend for new activity types, and improve UI consistency.